### PR TITLE
Устаревший параметр

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -251,7 +251,7 @@
             "message": "В проекте двойные кавычки"
         }],
 
-        "selector-attribute-operator-blacklist": [["id"], {
+        "selector-attribute-operator-disallowed-list": [["id"], {
             "message": "Для стилизации ID использовать нельзя"
         }],
         "selector-pseudo-class-case": ["lower", {


### PR DESCRIPTION
'selector-attribute-operator-blacklist' has been deprecated. Instead use 'selector-attribute-operator-disallowed-list'. See: https://github.com/stylelint/stylelint/blob/13.7.0/lib/rules/selector-attribute-operator-blacklist/README.md